### PR TITLE
Create achavi URLs in notifications of changesets from new users

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -541,7 +541,7 @@ class OSM(callbacks.Plugin):
                     except urllib2.HTTPError as e:
                         log.error("HTTP problem when looking for edit location: %s" % (e))
 
-                response = "%s just started editing%s with changeset http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'])
+                response = "%s just started editing%s with changeset https://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'])
                 log.info(response)
                 irc = world.ircs[0]
                 for chan in irc.state.channels:
@@ -560,7 +560,7 @@ class OSM(callbacks.Plugin):
                     except urllib2.HTTPError as e:
                         log.error("HTTP problem when looking for changeset location: %s" % (e))
 
-                response = "%s edited%s with changeset http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'])
+                response = "%s edited%s with changeset https://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'])
                 log.info(response)
                 irc = world.ircs[0]
                 for chan in irc.state.channels:

--- a/plugin.py
+++ b/plugin.py
@@ -541,7 +541,7 @@ class OSM(callbacks.Plugin):
                     except urllib2.HTTPError as e:
                         log.error("HTTP problem when looking for edit location: %s" % (e))
 
-                response = "%s just started editing%s with changeset https://osm.org/changeset/%s" % (data['username'], location, data['changeset'])
+                response = "%s just started editing%s with changeset https://osm.org/changeset/%s - http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'], data['changeset'])
                 log.info(response)
                 irc = world.ircs[0]
                 for chan in irc.state.channels:
@@ -560,7 +560,7 @@ class OSM(callbacks.Plugin):
                     except urllib2.HTTPError as e:
                         log.error("HTTP problem when looking for changeset location: %s" % (e))
 
-                response = "%s edited%s with changeset https://osm.org/changeset/%s" % (data['username'], location, data['changeset'])
+                response = "%s edited%s with changeset https://osm.org/changeset/%s - http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'], data['changeset'])
                 log.info(response)
                 irc = world.ircs[0]
                 for chan in irc.state.channels:

--- a/plugin.py
+++ b/plugin.py
@@ -541,7 +541,7 @@ class OSM(callbacks.Plugin):
                     except urllib2.HTTPError as e:
                         log.error("HTTP problem when looking for edit location: %s" % (e))
 
-                response = "%s just started editing%s with changeset https://osm.org/changeset/%s - http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'], data['changeset'])
+                response = "%s just started editing%s with changeset http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'])
                 log.info(response)
                 irc = world.ircs[0]
                 for chan in irc.state.channels:
@@ -560,7 +560,7 @@ class OSM(callbacks.Plugin):
                     except urllib2.HTTPError as e:
                         log.error("HTTP problem when looking for changeset location: %s" % (e))
 
-                response = "%s edited%s with changeset https://osm.org/changeset/%s - http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'], data['changeset'])
+                response = "%s edited%s with changeset http://overpass-api.de/achavi/?changeset=%s" % (data['username'], location, data['changeset'])
                 log.info(response)
                 irc = world.ircs[0]
                 for chan in irc.state.channels:


### PR DESCRIPTION
Change the link from OSM.org changesets to  `https://overpass-api.de/achavi/?changeset=95575149` inthe messages from the osmbot-test notifing IRC channels about edits from new users

## Before

```
21:55:25 < osmbot-test> USER just started editing near Viken, Norge with changeset https://osm.org/changeset/95575149
```

## After

```
21:55:25 < osmbot-test> USER just started editing near Viken, Norge with changeset https://overpass-api.de/achavi/?changeset=95575149
```

Clickable URL for testing - https://overpass-api.de/achavi/?changeset=95575149

[FredrikLindseth](https://wiki.openstreetmap.org/wiki/User:FredrikLindseth) 🇳🇴


:pray: 
